### PR TITLE
chore(module): Update module path and import statements

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	"smartid/internal/client"
-	"smartid/internal/config"
+	"github.com/tab/smart-id/internal/client"
+	"github.com/tab/smart-id/internal/config"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module smartid
+module github.com/tab/smart-id
 
 go 1.23
 

--- a/internal/client/authenticate.go
+++ b/internal/client/authenticate.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/go-resty/resty/v2"
 
-	"smartid/internal/errors"
-	"smartid/internal/models"
+	"github.com/tab/smart-id/internal/errors"
+	"github.com/tab/smart-id/internal/models"
 )
 
 // Authenticate sends an authentication request to the Smart-ID provider

--- a/internal/client/authenticate_test.go
+++ b/internal/client/authenticate_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"smartid/internal/config"
-	"smartid/internal/models"
+	"github.com/tab/smart-id/internal/config"
+	"github.com/tab/smart-id/internal/models"
 )
 
 func Test_Authenticate(t *testing.T) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/go-resty/resty/v2"
 
-	"smartid/internal/config"
-	"smartid/internal/errors"
+	"github.com/tab/smart-id/internal/config"
+	"github.com/tab/smart-id/internal/errors"
 )
 
 const (

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"smartid/internal/config"
+	"github.com/tab/smart-id/internal/config"
 )
 
 func Test_NewClient(t *testing.T) {

--- a/internal/client/session.go
+++ b/internal/client/session.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/go-resty/resty/v2"
 
-	"smartid/internal/errors"
-	"smartid/internal/models"
+	"github.com/tab/smart-id/internal/errors"
+	"github.com/tab/smart-id/internal/models"
 )
 
 // Status fetches the status of a Smart-ID session

--- a/internal/client/session_test.go
+++ b/internal/client/session_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"smartid/internal/config"
-	"smartid/internal/models"
+	"github.com/tab/smart-id/internal/config"
+	"github.com/tab/smart-id/internal/models"
 )
 
 func Test_Session_Status(t *testing.T) {


### PR DESCRIPTION
Changed the module path from `smartid` to `github.com/tab/smart-id` and updated corresponding import statements